### PR TITLE
Modified Icon and Active State

### DIFF
--- a/MarkdownPreview.css
+++ b/MarkdownPreview.css
@@ -9,4 +9,14 @@
     width: 18px;
     height: 11px;
     padding-right: 8px;
+    opacity: .5;
+}
+
+#markdown-preview-icon.active {
+    background: url(markdown-mark-black.svg);    
+    background-size: 100%;
+}
+
+#markdown-preview-icon:hover {
+	opacity: .75;
 }

--- a/main.js
+++ b/main.js
@@ -103,8 +103,10 @@ define(function (require, exports, module) {
                 window.setTimeout(_resizeIframe);
             }
             _loadDoc(DocumentManager.getCurrentDocument());
+            $icon.toggleClass("active");
             $panel.show();
         } else {
+            $icon.toggleClass("active");
             $panel.hide();
         }
         EditorManager.resizeEditor();

--- a/markdown-mark-black.svg
+++ b/markdown-mark-black.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="208" height="128">
+	<rect style="fill:none;stroke:#000000;stroke-width:10" width="198" height="118" x="5" y="5" ry="10" />
+	<path style="fill:#000000" d="m 30,98 0,-68 20,0 20,25 20,-25 20,0 0,68 -20,0 0,-39 -20,25 -20,-25 0,39 z" />
+	<path style="fill:#000000" d="m 155,98 -30,-33 20,0 0,-35 20,0 0,35 20,0 z" />
+</svg>

--- a/markdown-mark.svg
+++ b/markdown-mark.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="208" height="128">
-	<rect style="fill:none;stroke:#000;stroke-width:10" width="198" height="118" x="5" y="5" ry="10" />
-	<path style="fill:#000" d="m 30,98 0,-68 20,0 20,25 20,-25 20,0 0,68 -20,0 0,-39 -20,25 -20,-25 0,39 z" />
-	<path style="fill:#000" d="m 155,98 -30,-33 20,0 0,-35 20,0 0,35 20,0 z" />
+	<rect style="fill:none;stroke:#808080;stroke-width:10" width="198" height="118" x="5" y="5" ry="10" />
+	<path style="fill:#808080" d="m 30,98 0,-68 20,0 20,25 20,-25 20,0 0,68 -20,0 0,-39 -20,25 -20,-25 0,39 z" />
+	<path style="fill:#808080" d="m 155,98 -30,-33 20,0 0,-35 20,0 0,35 20,0 z" />
 </svg>


### PR DESCRIPTION
I really want to use this for Edge Code in the next release so I made it behave like the other icons in Edge Code. 

Now when the markdown viewer window is active, the icon turns black. When the mouse hovers over it the icon darkens slightly. 
