### PR TITLE
Track the user's cursor position, keeping it scrolled into view and showing it with a fake cursor

### DIFF
--- a/markdown.css
+++ b/markdown.css
@@ -100,3 +100,5 @@ body{font-size:16px;}
   p, h2, h3 { orphans: 3; widows: 3; }
   h2, h3 { page-break-after: avoid; }
 }
+
+#X-MARKDOWN-CURSOR { display: inline-block; width: 1px; height: 1em; background: #000; }


### PR DESCRIPTION
This isn't quite ready to pull as-is:
- For some reason, calling `scrollIntoView()` on the fake cursor the very first time causes the entire Brackets window to scroll up a little bit (it fixes itself once you click back in the code editor). No idea why that is, since the iframe should be fully visible by the time we do this, and the cursor is just at the top of the document. I feel like there ought to be something we could do in the core of Brackets to prevent this problem generally, but I'm not sure what. Any thoughts?
- I left in the code that preserves the existing scroll pos on update, but I'm not sure if it's actually still useful, since the rule is now that it always tries to scroll to the cursor whenever you make a change or change the selection, and those are the only things that can trigger an update.
