### PR TITLE
Add "Literate CoffeeScript" support

### DIFF
--- a/main.js
+++ b/main.js
@@ -261,7 +261,7 @@ define(function (require, exports, module) {
             currentDoc = null;
         }
         
-        if (doc && /md|markdown|txt/.test(ext)) {
+        if (doc && /md|markdown|litcoffee|txt/.test(ext)) {
             currentDoc = doc;
             $(currentDoc).on("change", _documentChange);
             $icon.css({display: "block"});


### PR DESCRIPTION
Added code that enables the Markdown Preview extension when the viewed file's extension is `.litcoffee`, which is used by ["Literate CoffeeScript"](http://coffeescript.org/#literate). (`.coffee.md` is also a valid extension, but the code already covered that case since it picks up the `.md` goes with that to enabled the extension)
