### PR TITLE
Add a preference for setting file extensions

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -14,6 +14,10 @@
             <option value="serif">Classic</option>
         </select>
     </div>
+    <div class="md-settings-row">
+        <span class="md-settings-label">Extensions</span>
+        <input type="text" id="markdown-preview-extensions">
+    </div>
     <div>
         <span class="md-settings-label"></span>
         <label><input type="checkbox" id="markdown-preview-sync-scroll">Sync scroll position</label>


### PR DESCRIPTION
This allows users to set which file extensions can be previewed.

The preference can be set using the settings panel in the preview pane, or by setting `markdown-preview.extensions` to an array of file extensions in `brackets.json`.

The default extensions come from the `markdown` and `gfm` Language objects, plus `litcoffee` and `txt`, so that 07df49c82527e02ec94248d692f59a9e8c2c66e2 and 7de66ef8fd705aa81f5b615e6579fb1ecdd0ea51 are not undone.
