### PR TITLE
Adding a menu entry in View for markdown preview

### DIFF
--- a/main.js
+++ b/main.js
@@ -37,6 +37,8 @@ define(function (require, exports, module) {
         PopUpManager        = brackets.getModule("widgets/PopUpManager"),
         PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
         WorkspaceManager    = brackets.getModule("view/WorkspaceManager"),
+        CommandManager      = brackets.getModule("command/CommandManager"),
+        Menus               = brackets.getModule("command/Menus"),
         _                   = brackets.getModule("thirdparty/lodash");
 
     // Templates
@@ -58,6 +60,8 @@ define(function (require, exports, module) {
     var currentDoc,
         currentEditor,
         panel,
+        viewMenu,
+        toggleCmd,
         visible = false,
         realVisibility = false;
 
@@ -281,6 +285,8 @@ define(function (require, exports, module) {
             panel.hide();
             $iframe.hide();
         }
+
+        toggleCmd.setChecked(isVisible);
     }
 
     function _currentDocChangedHandler() {
@@ -304,9 +310,11 @@ define(function (require, exports, module) {
             currentEditor.on("scroll", _editorScroll);
             $icon.css({display: "block"});
             _setPanelVisibility(visible);
+            toggleCmd.setEnabled(true);
             _loadDoc(doc);
         } else {
             $icon.css({display: "none"});
+            toggleCmd.setEnabled(false);
             _setPanelVisibility(false);
         }
     }
@@ -340,6 +348,14 @@ define(function (require, exports, module) {
 
     // Add a document change handler
     MainViewManager.on("currentFileChange", _currentDocChangedHandler);
+
+    viewMenu = Menus.getMenu(Menus.AppMenuBar.VIEW_MENU);
+    toggleCmd = CommandManager.register("Markdown Preview", "toggleMarkdownPreview", _toggleVisibility);
+
+    viewMenu.addMenuItem(toggleCmd);
+
+    toggleCmd.setChecked(realVisibility);
+    toggleCmd.setEnabled(realVisibility);
 
     // currentDocumentChange is *not* called for the initial document. Use
     // appReady() to set initial state.

--- a/main.js
+++ b/main.js
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2012 Glenn Ruehle
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,
  * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,7 +21,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true,  regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, window, marked, _hideSettings */
+/*global define, brackets, $, window, _hideSettings */
 
 define(function (require, exports, module) {
     "use strict";
@@ -36,8 +36,6 @@ define(function (require, exports, module) {
         MainViewManager     = brackets.getModule("view/MainViewManager"),
         PopUpManager        = brackets.getModule("widgets/PopUpManager"),
         PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
-        Resizer             = brackets.getModule("utils/Resizer"),
-        StringUtils         = brackets.getModule("utils/StringUtils"),
         WorkspaceManager    = brackets.getModule("view/WorkspaceManager"),
         _                   = brackets.getModule("thirdparty/lodash");
 
@@ -45,17 +43,17 @@ define(function (require, exports, module) {
     var panelHTML       = require("text!templates/panel.html"),
         previewHTML     = require("text!templates/preview.html"),
         settingsHTML    = require("text!templates/settings.html");
-    
+
     // Local modules
     var marked          = require("lib/marked");
-    
+
     // jQuery objects
     var $icon,
         $iframe,
         $panel,
         $settingsToggle,
         $settings;
-    
+
     // Other vars
     var currentDoc,
         currentEditor,
@@ -68,7 +66,7 @@ define(function (require, exports, module) {
     _prefs.definePreference("useGFM", "boolean", false);
     _prefs.definePreference("theme", "string", "clean");
     _prefs.definePreference("syncScroll", "boolean", true);
-    
+
     // (based on code in brackets.js)
     function _handleLinkClick(e) {
         // Check parents too, in case link has inline formatting tags
@@ -84,19 +82,19 @@ define(function (require, exports, module) {
             }
             node = node.parentElement;
         }
-        
+
         // Close settings dropdown, if open
         _hideSettings();
     }
-    
+
     function _calcScrollPos() {
         var scrollInfo = currentEditor._codeMirror.getScrollInfo();
         var scrollPercentage = scrollInfo.top / (scrollInfo.height - scrollInfo.clientHeight);
         var scrollTop = ($iframe[0].contentDocument.body.scrollHeight - $iframe[0].clientHeight) * scrollPercentage;
-        
+
         return Math.round(scrollTop);
     }
-     
+
     function _editorScroll() {
         if (_prefs.get("syncScroll") && $iframe) {
             var scrollTop = _calcScrollPos();
@@ -104,7 +102,7 @@ define(function (require, exports, module) {
             $iframe[0].contentDocument.body.scrollTop = scrollTop;
         }
     }
-   
+
     function _loadDoc(doc, isReload) {
         if (doc && visible && $iframe) {
             var docText     = doc.getText(),
@@ -117,22 +115,22 @@ define(function (require, exports, module) {
             if (yamlMatch) {
                 docText = docText.substr(yamlMatch[0].length);
             }
-            
+
             if (isReload) {
                 scrollPos = $iframe.contents()[0].body.scrollTop;
             } else if (_prefs.get("syncScroll")) {
                 scrollPos = _calcScrollPos();
             }
-            
+
             // Parse markdown into HTML
             bodyText = marked(docText);
-            
+
             // Show URL in link tooltip
             bodyText = bodyText.replace(/(href=\"([^\"]*)\")/g, "$1 title=\"$2\"");
-            
+
             // Convert protocol-relative URLS
             bodyText = bodyText.replace(/src="\/\//g, "src=\"http://");
-            
+
             if (isReload) {
                 $iframe[0].contentDocument.body.innerHTML = bodyText;
             } else {
@@ -166,18 +164,18 @@ define(function (require, exports, module) {
             }
         }
     }
-    
+
     function _documentChange(e) {
         _loadDoc(e.target, true);
     }
-    
+
     function _resizeIframe() {
         if (visible && $iframe) {
             var iframeWidth = panel.$panel.innerWidth();
             $iframe.attr("width", iframeWidth + "px");
         }
     }
-    
+
     function _updateSettings() {
         // Format
         var useGFM = _prefs.get("useGFM");
@@ -185,11 +183,11 @@ define(function (require, exports, module) {
             breaks: useGFM,
             gfm: useGFM
         });
-        
+
         // Re-render
         _loadDoc(currentDoc);
     }
-    
+
     function _documentClicked(e) {
         if (!$settings.is(e.target) &&
                 !$settingsToggle.is(e.target) &&
@@ -197,7 +195,7 @@ define(function (require, exports, module) {
             _hideSettings();
         }
     }
-    
+
     function _hideSettings() {
         if ($settings) {
             $settings.remove();
@@ -205,57 +203,57 @@ define(function (require, exports, module) {
             $(window.document).off("mousedown", _documentClicked);
         }
     }
-    
+
     function _showSettings(e) {
         _hideSettings();
-        
+
         $settings = $(settingsHTML)
             .css({
                 right: 12,
                 top: $settingsToggle.position().top + $settingsToggle.outerHeight() + 12
             })
             .appendTo($panel);
-        
+
         $settings.find("#markdown-preview-format")
             .prop("selectedIndex", _prefs.get("useGFM") ? 1 : 0)
             .change(function (e) {
                 _prefs.set("useGFM", e.target.selectedIndex === 1);
                 _updateSettings();
             });
-        
+
         $settings.find("#markdown-preview-theme")
             .val(_prefs.get("theme"))
             .change(function (e) {
                 _prefs.set("theme", e.target.value);
                 _updateSettings();
             });
-        
+
         var $syncScroll = $settings.find("#markdown-preview-sync-scroll");
-        
+
         $syncScroll.change(function (e) {
             _prefs.set("syncScroll", e.target.checked);
             _editorScroll();
         });
-        
+
         if (_prefs.get("syncScroll")) {
             $syncScroll.attr("checked", true);
         }
-        
+
         PopUpManager.addPopUp($settings, _hideSettings, true);
         $(window.document).on("mousedown", _documentClicked);
     }
-    
+
     function _setPanelVisibility(isVisible) {
         if (isVisible === realVisibility) {
             return;
         }
-        
+
         realVisibility = isVisible;
         if (isVisible) {
             if (!panel) {
                 $panel = $(panelHTML);
                 $iframe = $panel.find("#panel-markdown-preview-frame");
-                
+
                 panel = WorkspaceManager.createBottomPanel("markdown-preview-panel", $panel);
                 $panel.on("panelResizeUpdate", function (e, newSize) {
                     $iframe.attr("height", newSize);
@@ -263,7 +261,7 @@ define(function (require, exports, module) {
                 $iframe.attr("height", $panel.height());
 
                 window.setTimeout(_resizeIframe);
-                
+
                 $settingsToggle = $("#markdown-settings-toggle")
                     .click(function (e) {
                         if ($settings) {
@@ -272,7 +270,7 @@ define(function (require, exports, module) {
                             _showSettings(e);
                         }
                     });
-                
+
                 $iframe.hide();
             }
             _loadDoc(DocumentManager.getCurrentDocument());
@@ -288,17 +286,17 @@ define(function (require, exports, module) {
     function _currentDocChangedHandler() {
         var doc = DocumentManager.getCurrentDocument(),
             ext = doc ? FileUtils.getFileExtension(doc.file.fullPath).toLowerCase() : "";
-        
+
         if (currentDoc) {
             currentDoc.off("change", _documentChange);
             currentDoc = null;
         }
-        
+
         if (currentEditor) {
             currentEditor.off("scroll", _editorScroll);
             currentEditor = null;
         }
-        
+
         if (doc && /md|markdown|litcoffee|txt/.test(ext)) {
             currentDoc = doc;
             currentDoc.on("change", _documentChange);
@@ -312,23 +310,23 @@ define(function (require, exports, module) {
             _setPanelVisibility(false);
         }
     }
-    
+
     function _toggleVisibility() {
         visible = !visible;
         _setPanelVisibility(visible);
     }
-    
+
     // Debounce event callback to avoid excess overhead
     // Update preview 300 ms ofter document change
     // Sync scroll 1ms after document scroll (just enough to ensure
     // the document scroll isn't blocked).
     _documentChange = _.debounce(_documentChange, 300);
     _editorScroll = _.debounce(_editorScroll, 1);
-    
+
     // Insert CSS for this extension
     ExtensionUtils.loadStyleSheet(module, "styles/MarkdownPreview.css");
-    
-    // Add toolbar icon 
+
+    // Add toolbar icon
     $icon = $("<a>")
         .attr({
             id: "markdown-preview-icon",
@@ -339,16 +337,16 @@ define(function (require, exports, module) {
         })
         .click(_toggleVisibility)
         .appendTo($("#main-toolbar .buttons"));
-    
+
     // Add a document change handler
     MainViewManager.on("currentFileChange", _currentDocChangedHandler);
-    
+
     // currentDocumentChange is *not* called for the initial document. Use
     // appReady() to set initial state.
     AppInit.appReady(function () {
         _currentDocChangedHandler();
     });
-    
+
     // Listen for resize events
     WorkspaceManager.on("workspaceUpdateLayout", _resizeIframe);
     $("#sidebar").on("panelCollapsed panelExpanded panelResizeUpdate", _resizeIframe);

--- a/main.js
+++ b/main.js
@@ -285,8 +285,6 @@ define(function (require, exports, module) {
             panel.hide();
             $iframe.hide();
         }
-
-        toggleCmd.setChecked(isVisible);
     }
 
     function _currentDocChangedHandler() {
@@ -322,6 +320,8 @@ define(function (require, exports, module) {
     function _toggleVisibility() {
         visible = !visible;
         _setPanelVisibility(visible);
+
+        toggleCmd.setChecked(visible);
     }
 
     // Debounce event callback to avoid excess overhead


### PR DESCRIPTION
Hi @gruehle this PR adds an option to enable/disable markdown view whenever it is available according to the current file. The same action that can be performed using the icon from the extension panel.
The reason for adding this option is to enable the extension to work and be accessible in those applications and IDEs based on Brackets, that could have the extension panel disabled or hidden, like the Intel XDK.

![markdown-preview-001](https://cloud.githubusercontent.com/assets/2309921/8892473/6948e2ea-332f-11e5-9924-bd80d259b53b.png)
![markdown-preview-002](https://cloud.githubusercontent.com/assets/2309921/8892474/6949ea78-332f-11e5-9969-faefd76f46d2.png)
![markdown-preview-003](https://cloud.githubusercontent.com/assets/2309921/8892475/694d0f00-332f-11e5-9fa4-e2c3869292f3.png)
![markdown-preview-004](https://cloud.githubusercontent.com/assets/2309921/8892476/694ebfee-332f-11e5-95b9-1bbc746d668e.png)

Thanks!
