### PR TITLE
Update _.template-data formatting for lodash 3.10.0 compatibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -142,7 +142,7 @@ define(function (require, exports, module) {
                 var baseUrl = window.location.protocol + "//" + FileUtils.getDirectoryPath(doc.file.fullPath);
 
                 // Assemble the HTML source
-                var htmlSource = _.template(previewHTML, {
+                var htmlSource = _.template(previewHTML)({
                     baseUrl    : baseUrl,
                     themeUrl   : require.toUrl("./themes/" + _prefs.get("theme") + ".css"),
                     scrollTop  : scrollPos,


### PR DESCRIPTION
Fixes #87.

Brackets was updated to use `lodash#3.10.0`, which removed the `data` parameter from `_.template` in version 3.0.0.
The new format is `.template(templateHTML)(dataObj)`.

See https://github.com/lodash/lodash/wiki/Changelog for reference, under 3.0.0
