### PR TITLE
activate brackets plugin on .mkd files too

### DIFF
--- a/main.js
+++ b/main.js
@@ -301,7 +301,7 @@ define(function (require, exports, module) {
             currentEditor = null;
         }
 
-        if (doc && /md|markdown|litcoffee|txt/.test(ext)) {
+        if (doc && /md|mkd|markdown|litcoffee|txt/.test(ext)) {
             currentDoc = doc;
             currentDoc.on("change", _documentChange);
             currentEditor = EditorManager.getCurrentFullEditor();


### PR DESCRIPTION
ReText markdown editor saves files as .mkd by default. Opening those files in Brackets does not currently activate the MarkdownPreview plugin.
