### PR TITLE
Add preview text width setting

### DIFF
--- a/main.js
+++ b/main.js
@@ -70,6 +70,7 @@ define(function (require, exports, module) {
     _prefs.definePreference("useGFM", "boolean", false);
     _prefs.definePreference("theme", "string", "clean");
     _prefs.definePreference("syncScroll", "boolean", true);
+    _prefs.definePreference("textWidth", "string", 80); //in CSS em's
 
     // (based on code in brackets.js)
     function _handleLinkClick(e) {
@@ -146,7 +147,8 @@ define(function (require, exports, module) {
                     baseUrl    : baseUrl,
                     themeUrl   : require.toUrl("./themes/" + _prefs.get("theme") + ".css"),
                     scrollTop  : scrollPos,
-                    bodyText   : bodyText
+                    bodyText   : bodyText,
+                    textWidth  : _prefs.get("textWidth")
                 });
                 $iframe.attr("srcdoc", htmlSource);
 
@@ -232,6 +234,27 @@ define(function (require, exports, module) {
                 _updateSettings();
             });
 
+		
+        var $width = $settings.find("#markdown-preview-text-width")
+            .val(_prefs.get("textWidth"))
+            .change(function (e) {
+				_prefs.set("textWidth", e.target.value);
+				_updateSettings();
+			});
+			
+		var timer = null;
+		$width.keyup(function(e) {
+			if (timer != null) {
+				clearTimeout(timer);
+			}
+			timer = setTimeout(function() {
+				timer = null;  
+				_prefs.set("textWidth", e.target.value);
+				_updateSettings();
+			  }, 300); 
+		})
+
+        
         var $syncScroll = $settings.find("#markdown-preview-sync-scroll");
 
         $syncScroll.change(function (e) {

--- a/styles/MarkdownPreview.css
+++ b/styles/MarkdownPreview.css
@@ -73,7 +73,7 @@
 .md-settings-label {
     display: inline-block;
     text-align: right;
-    width: 55px;
+    width: 85px;
     height: 27px;
     padding-right: 10px;
     vertical-align: middle;

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -4,7 +4,7 @@
         <base href="<%= baseUrl %>">
         <link rel="stylesheet" href = "<%= themeUrl %>">
     </head>
-    <body onload="document.body.scrollTop = <%= scrollTop %>">
+    <body onload="document.body.scrollTop = <%= scrollTop %>" style="max-width: <%= textWidth %>em">
         <%= bodyText %>
         <script>
             // Set scrollTop as soon as the body is parsed. This help with flicker when

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -14,6 +14,10 @@
             <option value="serif">Classic</option>
         </select>
     </div>
+    <div class="md-settings-row">
+        <span class="md-settings-label">Text width (em)</span>
+        <input type="text" size="3" maxlength="3" id="markdown-preview-text-width">
+    </div>
     <div>
         <span class="md-settings-label"></span>
         <label><input type="checkbox" id="markdown-preview-sync-scroll">Sync scroll position</label>


### PR DESCRIPTION
Depending on monitor size the default preview width is sometime too small.
The new "Text width" setting is added to adjust the width "on the fly".